### PR TITLE
Install dependency (webdriver-manager) directly from github

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
 browser =
   selenium
   pandas
-  webdriver-manager
+  webdriver-manager @ git+https://github.com/SergeyPirogov/webdriver_manager.git
 
 [options.packages.find]
 where=src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stac-utils-python
-version = 0.0.4
+version = 0.0.5
 author = Micheál Keane
 author_email = micheal@staclabs.io
 description = Stac Labs python utilities

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
 browser =
   selenium
   pandas
-  undetected_chromedriver
   webdriver-manager
 
 [options.packages.find]


### PR DESCRIPTION
Google changed the naming scheme for chromedriver files for m1 macs which broke webdriver-manager which is responsible for pulling down said driver. A fix has been merged into the most recent commit on the library's github repo but hasn't been released.

I did a test run locally to install the library from this branch and it seems I got the nomenclature correct. We should definitely remember to revisit this after the election to go back to releases.