### PR TITLE
auto credential in Portal

### DIFF
--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+from typing import Union
 
 from google.api_core.exceptions import InternalServerError
 from google.api_core.retry import if_exception_type, Retry
@@ -19,7 +20,7 @@ RETRY_EXCEPTIONS = [InternalServerError]
 def get_credentials(
     service_account_blob: dict = None,
     service_account_env_name: str = "SERVICE_ACCOUNT",
-    scopes: [list[str], str] = None,
+    scopes: Union[list[str], str] = None,
     subject: str = None,
 ) -> service_account.Credentials:
     """Loads a Google Service Account into a Credentials object with the given scopes"""
@@ -44,16 +45,19 @@ def get_credentials(
     return credentials
 
 
-def auth_bq() -> bigquery.Client:
+def auth_bq(is_auto_credential: bool = False) -> bigquery.Client:
     """Returns an initialized BigQuery client object"""
 
     scopes = ["cloud-platform", "drive"]
     credentials = get_credentials(scopes=scopes)
 
-    client = bigquery.Client(
-        credentials=credentials,
-        project=credentials.project_id,
-    )
+    if is_auto_credential:
+        client = bigquery.Client()
+    else:
+        client = bigquery.Client(
+            credentials=credentials,
+            project=credentials.project_id,
+        )
 
     return client
 
@@ -65,8 +69,11 @@ def run_query(
     client: bigquery.Client = None,
     retry_exceptions: list = None,
     job_config: bigquery.QueryJobConfig = None,
+    is_auto_credential: bool = False
 ) -> list[dict]:
     """Performs a SQL query in BigQuery"""
+    if is_auto_credential:
+        client = bigquery.Client()
     if not client:
         if not service_account_blob:
             try:

--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -49,11 +49,11 @@ def auth_bq(is_auto_credential: bool = False) -> bigquery.Client:
     """Returns an initialized BigQuery client object"""
 
     scopes = ["cloud-platform", "drive"]
-    credentials = get_credentials(scopes=scopes)
 
     if is_auto_credential:
         client = bigquery.Client()
     else:
+        credentials = get_credentials(scopes=scopes)
         client = bigquery.Client(
             credentials=credentials,
             project=credentials.project_id,

--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -69,7 +69,7 @@ def run_query(
     client: bigquery.Client = None,
     retry_exceptions: list = None,
     job_config: bigquery.QueryJobConfig = None,
-    is_auto_credential: bool = False
+    is_auto_credential: bool = False,
 ) -> list[dict]:
     """Performs a SQL query in BigQuery"""
     if is_auto_credential:
@@ -103,9 +103,10 @@ def get_table(
     service_account_blob: dict[str, str] = None,
     service_account_env_name: str = "SERVICE_ACCOUNT",
     subject: str = None,
+    client: bigquery.Client = None,
 ) -> list[dict]:
     """Performs a select * from the given table in BigQuery"""
-    if not service_account_blob:
+    if not service_account_blob and not client:
         try:
             service_account_blob = json.loads(os.environ[service_account_env_name])
         except json.JSONDecodeError:
@@ -113,7 +114,12 @@ def get_table(
 
     # sadly bq's parameterized queries don't support table names
     sql = f"SELECT * FROM `{_sanitize_name(table_name)}`;"
-    results = run_query(sql, service_account_blob=service_account_blob, subject=subject)
+    results = run_query(
+        sql,
+        service_account_blob=service_account_blob,
+        client=client,
+        subject=subject,
+    )
 
     return results
 

--- a/src/stac_utils/http.py
+++ b/src/stac_utils/http.py
@@ -2,6 +2,7 @@ import time
 import logging
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from typing import Union
 
 import requests
 
@@ -94,7 +95,7 @@ class HTTPClient(Client):
 
     def check_response_for_rate_limit(
         self, response: requests.Response
-    ) -> [int, float, None]:
+    ) -> Union[int, float, None]:
         """Inspect the response for rate limit information"""
 
         return None


### PR DESCRIPTION
for Portal scripts and state party service accounts, simply doing bigquery.Client() without additional creds suffices and is necessary.

ah...I realize this adds to the kludginess, but we can fix that on the upcoming ticket can't we!