### PR TITLE
ticker is_testing flag

### DIFF
--- a/src/stac_utils/ticker_request.py
+++ b/src/stac_utils/ticker_request.py
@@ -76,7 +76,7 @@ class TickerRequest(HTTPClient):
                 "task": task,
                 "metric": metric,
                 "amount": amount,
-                "is_test": os.environ.get("IS_TESTING", "")
+                "is_testing": os.environ.get("IS_TESTING", "")
             }
         )
 

--- a/src/stac_utils/ticker_request.py
+++ b/src/stac_utils/ticker_request.py
@@ -76,6 +76,7 @@ class TickerRequest(HTTPClient):
                 "task": task,
                 "metric": metric,
                 "amount": amount,
+                "is_test": os.environ.get("IS_TESTING", "")
             }
         )
 

--- a/src/tests/test_email.py
+++ b/src/tests/test_email.py
@@ -59,6 +59,33 @@ class TestEmailer(unittest.TestCase):
         )
 
     @patch("requests.post")
+    def test_send_email_with_template(self, mock_post: MagicMock):
+        """Test send email"""
+        test_emailer = Emailer("foo", "bar")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+        test_emailer.send_email(
+            "foo",
+            template="barTemplate",
+            variables={"variable": "misc"},
+            emails=["spam@foo.bar"],
+        )
+        mock_post.assert_called_once_with(
+            f"https://api.mailgun.net/v3/foo/messages",
+            auth=("api", "bar"),
+            data={
+                "to": "spam@foo.bar",
+                "from": None,
+                "subject": "foo",
+                "h:Reply-to": [],
+                "template": "barTemplate",
+                "t:variables": '{"variable": "misc"}',
+            },
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("requests.post")
     def test_send_email_custom_reply_to(self, mock_post: MagicMock):
         """Test send email with custom reply to"""
         test_emailer = Emailer("foo", "bar", reply_to="no@foo.bar")

--- a/src/tests/test_ticker_request.py
+++ b/src/tests/test_ticker_request.py
@@ -81,7 +81,7 @@ class TestTickerRequest(unittest.TestCase):
                 "source": "foo",
                 "task": "bar",
                 "metric": "spam",
-                "amount": 42.0
+                "amount": 42.0,
             }
             test_ticker.add_data(**test_data)
 
@@ -103,7 +103,7 @@ class TestTickerRequest(unittest.TestCase):
                 "source": "foo",
                 "task": "bar",
                 "metric": "spam",
-                "amount": 42.0
+                "amount": 42.0,
             }
             test_ticker.add_data(**test_data)
             test_response = test_ticker.send_to_ticker()
@@ -138,7 +138,7 @@ class TestTickerRequest(unittest.TestCase):
                 "source": "foo",
                 "task": "bar",
                 "metric": "spam",
-                "amount": 42.0
+                "amount": 42.0,
             }
             test_ticker.add_data(**test_data)
             self.assertRaises(TickerException, test_ticker.send_to_ticker)

--- a/src/tests/test_ticker_request.py
+++ b/src/tests/test_ticker_request.py
@@ -82,6 +82,7 @@ class TestTickerRequest(unittest.TestCase):
                 "task": "bar",
                 "metric": "spam",
                 "amount": 42.0,
+                "is_testing": ""
             }
             test_ticker.add_data(**test_data)
 
@@ -102,6 +103,7 @@ class TestTickerRequest(unittest.TestCase):
                 "task": "bar",
                 "metric": "spam",
                 "amount": 42.0,
+                "is_testing": ""
             }
             test_ticker.add_data(**test_data)
             test_response = test_ticker.send_to_ticker()
@@ -135,6 +137,7 @@ class TestTickerRequest(unittest.TestCase):
                 "task": "bar",
                 "metric": "spam",
                 "amount": 42.0,
+                "is_testing": ""
             }
             test_ticker.add_data(**test_data)
             self.assertRaises(TickerException, test_ticker.send_to_ticker)

--- a/src/tests/test_ticker_request.py
+++ b/src/tests/test_ticker_request.py
@@ -81,12 +81,13 @@ class TestTickerRequest(unittest.TestCase):
                 "source": "foo",
                 "task": "bar",
                 "metric": "spam",
-                "amount": 42.0,
-                "is_testing": ""
+                "amount": 42.0
             }
             test_ticker.add_data(**test_data)
 
-            self.assertListEqual(test_ticker.data, [test_data])
+            test_result = test_data.copy()
+            test_result["is_testing"] = ""
+            self.assertListEqual(test_ticker.data, [test_result])
 
     def test_send_to_ticker(self):
         """Test send to ticker"""
@@ -102,13 +103,14 @@ class TestTickerRequest(unittest.TestCase):
                 "source": "foo",
                 "task": "bar",
                 "metric": "spam",
-                "amount": 42.0,
-                "is_testing": ""
+                "amount": 42.0
             }
             test_ticker.add_data(**test_data)
             test_response = test_ticker.send_to_ticker()
 
-            test_ticker.post.assert_called_once_with("/ticker", body=[test_data])
+            test_result = test_data.copy()
+            test_result["is_testing"] = ""
+            test_ticker.post.assert_called_once_with("/ticker", body=[test_result])
             self.assertIs(test_response, mock_response)
             self.assertListEqual(test_ticker.data, [])
 
@@ -136,14 +138,15 @@ class TestTickerRequest(unittest.TestCase):
                 "source": "foo",
                 "task": "bar",
                 "metric": "spam",
-                "amount": 42.0,
-                "is_testing": ""
+                "amount": 42.0
             }
             test_ticker.add_data(**test_data)
             self.assertRaises(TickerException, test_ticker.send_to_ticker)
 
-            test_ticker.post.assert_called_once_with("/ticker", body=[test_data])
-            self.assertListEqual(test_ticker.data, [test_data])
+            test_result = test_data.copy()
+            test_result["is_testing"] = ""
+            test_ticker.post.assert_called_once_with("/ticker", body=[test_result])
+            self.assertListEqual(test_ticker.data, [test_result])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Note: most of the uncovered codecov flagged lines are in fact from a previous PR involving google.py updates that didn't go through to codecov for some reason. Since we're rewriting google.py anyway, ignore all of that!