### PR TITLE
Convert ID to EID for VAN things

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to stac-utils-python's documentation!
    stac_utils.bsd
    stac_utils.convert
    stac_utils.database_utils
+   stac_utils.eid
    stac_utils.email
    stac_utils.google
    stac_utils.http

--- a/src/stac_utils/__init__.py
+++ b/src/stac_utils/__init__.py
@@ -1,3 +1,4 @@
+from .eid import convert_to_eid
 from .listify import listify
 from .secret_context import secrets
 from .convert import convert_to_snake_case

--- a/src/stac_utils/eid.py
+++ b/src/stac_utils/eid.py
@@ -1,0 +1,12 @@
+def convert_to_eid(id: int) -> str:
+    """
+    Convert an ID, such as a VAN ID or an export request ID, into an EID string.
+    Useful for creating direct links to VoteBuilder.
+    :param id: ID number to convert
+    :return: EID
+    """
+    ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    reverse_hex_id = f"{id:x}"[::-1]
+    letter = ALPHABET[id % 17]
+
+    return f"EID{reverse_hex_id}{letter}".upper()

--- a/src/stac_utils/jira.py
+++ b/src/stac_utils/jira.py
@@ -49,7 +49,12 @@ class JiraClient(HTTPClient):
         return session
 
     def transform_response(self, response: requests.Response, **kwargs):
-        """Transforms the response from the API to JSON"""
+        """
+        Transforms the response from the API to JSON
+
+        :param response: API response
+        :return: JSON data
+        """
 
         try:
             data = response.json() or {}
@@ -65,12 +70,20 @@ class JiraClient(HTTPClient):
 
     @staticmethod
     def get_issue_url(issue_key: str) -> str:
-        """Returns the API end point to GET an issue"""
+        """
+        Returns the API end point to GET an issue
+
+        :param issue_key: string with the Jira ticket ID
+        :return: endpoint string to GET info about the ticket
+        """
         return f"rest/api/3/issue/{issue_key}"
 
     def get_issue_transitions_url(self, issue_key: str) -> str:
         """
         Returns the API end point to GET the transitions now
         possible for an issue, given its current status
+
+        :param issue_key: string with the Jira ticket ID
+        :return: endpoint string to interact with the ticket's transitions
         """
         return f"{self.get_issue_url(issue_key)}/transitions"

--- a/src/tests/test_eid.py
+++ b/src/tests/test_eid.py
@@ -1,0 +1,13 @@
+import unittest
+
+from src.stac_utils.eid import convert_to_eid
+
+
+class TestEid(unittest.TestCase):
+    def test_convert_to_eid(self):
+        self.assertEqual(convert_to_eid(1), "EID1B")
+        self.assertEqual(convert_to_eid(4391), "EID7211F")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Checklist for this pull request:
- [x] I have added docstrings to my additions if needed
- [x] I have added the module to docs/index.rst if it is completely new

### Description:
Should, if old Slack conversations are correct, convert integers to EIDs for VAN links. Have tested on a few export request IDs also.