### PR TITLE
Fix some Google util issues

### DIFF
--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+import itertools
 
 from google.api_core.exceptions import InternalServerError, NotFound
 from google.api_core.retry import if_exception_type, Retry
@@ -401,10 +402,13 @@ def load_data_from_dataframe(
         chunk_size=10000,
         retry=retry_policy,
     )
-    
-    logger.info(f"inserted {len(results)} rows")
-    print(results)
 
+    print(f'completed insert to {table}')
+    if len(results) > 0:
+        # any result from insert_rows_to_dataframe indicates errors in some rows, log them
+        logger.error(f'Errors encountered inserting to {table}')
+        errors = itertools.chain(results)
+        logger.error(errors)
 
 
 def load_data_from_list(

--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -24,6 +24,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+
 def get_credentials(
     service_account_blob: dict = None,
     service_account_env_name: str = "SERVICE_ACCOUNT",
@@ -348,7 +349,14 @@ def create_table_from_dataframe(
     """
     print(table_definition_sql)
     run_query(table_definition_sql, client=client)
-    load_data_from_dataframe(client, dataframe, project_name, dataset_name, table_name, retry_exceptions=[NotFound, *RETRY_EXCEPTIONS])
+    load_data_from_dataframe(
+        client,
+        dataframe,
+        project_name,
+        dataset_name,
+        table_name,
+        retry_exceptions=[NotFound, *RETRY_EXCEPTIONS],
+    )
 
 
 def get_table_for_loading(
@@ -403,10 +411,10 @@ def load_data_from_dataframe(
         retry=retry_policy,
     )
 
-    print(f'completed insert to {table}')
+    print(f"completed insert to {table}")
     if len(results) > 0:
         # any result from insert_rows_to_dataframe indicates errors in some rows, log them
-        logger.error(f'Errors encountered inserting to {table}')
+        logger.error(f"Errors encountered inserting to {table}")
         errors = itertools.chain(results)
         logger.error(errors)
 

--- a/src/tests/test_google.py
+++ b/src/tests/test_google.py
@@ -483,7 +483,9 @@ class TestGoogle(unittest.TestCase):
         mock_auth_sheets.return_value = mock_client
         mock_modifier = MagicMock()
         mock_client.spreadsheets.return_value.values.return_value = mock_modifier
-        send_data_to_sheets([[1, None, 2], [3, 4, 5]], "foo", "bar", is_fill_in_nulls=True)
+        send_data_to_sheets(
+            [[1, None, 2], [3, 4, 5]], "foo", "bar", is_fill_in_nulls=True
+        )
         mock_modifier.append.assert_not_called()
         mock_modifier.update.assert_called_once_with(
             spreadsheetId="foo",

--- a/src/tests/test_google.py
+++ b/src/tests/test_google.py
@@ -308,14 +308,14 @@ class TestGoogle(unittest.TestCase):
     ):
         """Test create table from dataframe"""
 
-        mock_df = pd.DataFrame([{"foo": 1, "bar": 2.5, "spam": "spam"}])
+        mock_df = pd.DataFrame([{"foo": 1, "bar": 2.5, "spam": "spam", "baz": False}])
 
         table_definition_sql = f"""
         DROP TABLE IF EXISTS 
             foo.bar.spam 
         ;
         CREATE TABLE foo.bar.spam ( 
-            foo INT64, bar NUMERIC, spam STRING
+            foo INT64, bar NUMERIC, spam STRING, baz BOOL
         );
     """
 


### PR DESCRIPTION
### Checklist for this pull request:
- [x] I have added docstrings to my additions if needed
- [x] I have added the module to docs/index.rst if it is completely new

### Description:

Cleans up a few issues with Google utils, surface errors in inserts.

- allows retry of `NotFound` errors on table inserts for up to 120 seconds. Google creates tables _eventually_ when the create table SQL is run, so we were running into issues where tables were sometimes not immediately available. 120 second timeout
- adds support for `boolean` columns to write to BQ as boolean columns 
- fixes some logging statements
- changes how we access columns to use `iloc`, getting rid of a deprecation warning
- outputs results from inserts as errors when there are issues instead of silently failing 