### PR TITLE
Revert ""[ci skip] Bump version: 0.2.9 → 0.3.0""

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.2.9
 message = "[ci skip] Bump version: {current_version} → {new_version}"
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stac-utils-python
-version = 0.3.0
+version = 0.2.9
 author = Micheál Keane
 author_email = micheal@staclabs.io
 description = Stac Labs python utilities


### PR DESCRIPTION
This reverts commit 116854481ab3ebc8b5af22546e2e163a19ce788e.

### Checklist for this pull request:
- [x] I have added docstrings to my additions if needed
- [x] I have added the module to docs/index.rst if it is completely new

### Description:

Rolling back the 0.3.0 release.