### PR TITLE
"[ci skip] Bump version: 0.2.9 → 0.2.10"

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.9
+current_version = 0.2.10
 message = "[ci skip] Bump version: {current_version} → {new_version}"
 commit = True
 tag = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stac-utils-python
-version = 0.2.9
+version = 0.2.10
 author = Micheál Keane
 author_email = micheal@staclabs.io
 description = Stac Labs python utilities


### PR DESCRIPTION
### Checklist for this pull request:
- [x] I have added docstrings to my additions if needed
- [x] I have added the module to docs/index.rst if it is completely new

### Description:

This is really silly but necessary because the bumpversion automation is broken on circleci.