### PR TITLE
handle tabs in email addresses because the ngpvan api won't

### DIFF
--- a/src/stac_utils/email.py
+++ b/src/stac_utils/email.py
@@ -47,8 +47,9 @@ class Emailer:
         :param template: Specified template for email
         :param variables: Specified variables for email template
         """
+        cleaned_emails = [email.strip() for email in emails]
         email_data = {
-            "to": ",".join(emails),
+            "to": ",".join(cleaned_emails),
             "from": from_addr or self.from_addr,
             "subject": subject,
             "h:Reply-to": listify(reply_to) or self.reply_to,
@@ -107,6 +108,4 @@ class SMTPEmailer:
             email_data["Reply-To"] = ",".join(reply_to)
         email_data.attach(MIMEText(body, "html"))
 
-        return self.client.sendmail(
-            self.username, emails, email_data.as_string()
-        )
+        return self.client.sendmail(self.username, emails, email_data.as_string())

--- a/src/stac_utils/ngpvan.py
+++ b/src/stac_utils/ngpvan.py
@@ -179,7 +179,7 @@ class NGPVANClient(HTTPClient):
             print("No ID key used")
 
         if row.get("email"):
-            formatted_json["emails"] = [{"email": row.get("email")}]
+            formatted_json["emails"] = [{"email": row.get("email").strip()}]
 
         if row.get("phone"):
             formatted_json["phones"] = [

--- a/src/tests/test_ngpvan.py
+++ b/src/tests/test_ngpvan.py
@@ -321,6 +321,26 @@ class TestNGPVAN(unittest.TestCase):
             },
         )
 
+        self.assertEqual(
+            NGPVANClient.format_person_json(
+                {
+                    "first_name": "John",
+                    "last_name": "Smith",
+                    "date_of_birth": "1984-01-01",
+                    "email": "foo@aol.com\t\t\t",
+                },
+                None,
+                False,
+            ),
+            {
+                "firstName": "John",
+                "lastName": "Smith",
+                "dateOfBirth": "1984-01-01",
+                "emails": [{"email": "foo@aol.com"}],
+                "contactMode": "Person",
+            },
+        )
+
         self.assertRaises(
             ValueError,
             NGPVANClient.format_person_json,


### PR DESCRIPTION
### Checklist for this pull request:
- [] I have added docstrings to my additions if needed
- [] I have added the module to docs/index.rst if it is completely new

### Description:
no new modules or methods. added .strip() in a couple places to deal with tabs in email addresses (problem was occurring with ngpvan api). also added to format_person_json test in ngpvan tests. i did not add to tests of emailer but can do that if needed

