### PR TITLE
Initial pass at more logging and support for extra secrets

### DIFF
--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -41,15 +41,18 @@ def secrets(
     values = {}
     values["LOADED_SECRET_NAMES"] = os.environ.get("LOADED_SECRET_NAMES", [])
 
-    if not secret_name and os.environ.get("SECRET_NAME"):
-        secret_name = os.environ.get("SECRET_NAME")
-        # blank secret name in the context, so it doesn't get loaded a second time
-        # if we nest secrets
-        values["SECRET_NAME"] = ""
+    # if not secret_name and os.environ.get("SECRET_NAME"):
+    #     secret_name = os.environ.get("SECRET_NAME")
+    #     # blank secret name in the context, so it doesn't get loaded a second time
+    #     # if we nest secrets
+    #     values["SECRET_NAME"] = ""
 
     # Find secret names 
     pattern = re.compile(r'^SECRET_NAME_')
     secret_names = [key for key in os.environ if pattern.match(key)]
+
+    if "SECRET_NAME" in os.environ:
+        secret_names.insert(0, "SECRET_NAME")
 
     if secret_name:
         secret_names.insert(0, secret_name)

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -58,8 +58,9 @@ def secrets(
         secret_names.insert(0, secret_name)
 
     for secret_key in secret_names:
-        if secret_key not in values["LOADED_SECRET_NAMES"]:
-            key_from_environ = os.environ.get(secret_key)
+        key_from_environ = os.environ.get(secret_key)
+
+        if key_from_environ not in values["LOADED_SECRET_NAMES"]:
             logger.info(f'Loading secret {key_from_environ} from region {secret_region}')
 
             secret_vals = get_secret(
@@ -75,11 +76,11 @@ def secrets(
                 raise ValueError(err_msg)
             
             values.update(secret_vals)
-            values["LOADED_SECRET_NAMES"].append(secret_key)
+            values["LOADED_SECRET_NAMES"].append(key_from_environ)
 
             logger.info(f'Successfully loaded {len(secret_vals)} values from secret {key_from_environ}')
         else:
-            logger.info(f'Secret {secret_key} already loaded - skipping')
+            logger.info(f'Secret {key_from_environ} already loaded - skipping')
 
     if not s3_url and os.environ.get("SECRET_S3_URL"):
         s3_url = os.environ.get("SECRET_S3_URL")

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -79,7 +79,7 @@ def secrets(
 
             logger.info(f'Successfully loaded {len(secret_vals)} values from secret {key_from_environ}')
         else:
-            logger.info(f'Secret {key_from_environ} already loaded - skipping')
+            logger.info(f'Secret {secret_key} already loaded - skipping')
 
     if not s3_url and os.environ.get("SECRET_S3_URL"):
         s3_url = os.environ.get("SECRET_S3_URL")

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -5,7 +5,6 @@ import logging
 from unittest.mock import patch
 
 from .aws import get_secret, split_s3_url, load_from_s3
-from .listify import listify
 
 logger = logging.getLogger(__name__)
 
@@ -40,10 +39,7 @@ def secrets(
     secret_region = aws_region or os.environ.get("AWS_REGION") or "us-east-1"
 
     values = {}
-    values["LOADED_SECRET_NAMES"] = os.environ.get("LOADED_SECRET_NAMES", [])
-
-    if isinstance(values["LOADED_SECRET_NAMES"], str):
-        values["LOADED_SECRET_NAMES"] = listify(values["LOADED_SECRET_NAMES"])
+    values["LOADED_SECRET_NAMES"] = json.loads(os.environ.get("LOADED_SECRET_NAMES", []))
 
     # if not secret_name and os.environ.get("SECRET_NAME"):
     #     secret_name = os.environ.get("SECRET_NAME")

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -40,7 +40,10 @@ def secrets(
     secret_region = aws_region or os.environ.get("AWS_REGION") or "us-east-1"
 
     values = {}
-    values["LOADED_SECRET_NAMES"] = listify(os.environ.get("LOADED_SECRET_NAMES", []))
+    values["LOADED_SECRET_NAMES"] = os.environ.get("LOADED_SECRET_NAMES", [])
+
+    if isinstance(values["LOADED_SECRET_NAMES"], str):
+        values["LOADED_SECRET_NAMES"] = listify(values["LOADED_SECRET_NAMES"])
 
     # if not secret_name and os.environ.get("SECRET_NAME"):
     #     secret_name = os.environ.get("SECRET_NAME")

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -39,7 +39,7 @@ def secrets(
     secret_region = aws_region or os.environ.get("AWS_REGION") or "us-east-1"
 
     values = {}
-    values["LOADED_SECRET_NAMES"] = json.loads(os.environ.get("LOADED_SECRET_NAMES", []))
+    values["LOADED_SECRET_NAMES"] = json.loads(os.environ.get("LOADED_SECRET_NAMES", "[]"))
 
     # if not secret_name and os.environ.get("SECRET_NAME"):
     #     secret_name = os.environ.get("SECRET_NAME")

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -75,7 +75,7 @@ def secrets(
                 raise ValueError(err_msg)
             
             values.update(secret_vals)
-            values["LOADED_SECRET_NAMES"].append(key_from_environ)
+            values["LOADED_SECRET_NAMES"].append(secret_key)
 
             logger.info(f'Successfully loaded {len(secret_vals)} values from secret {key_from_environ}')
         else:

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -5,6 +5,7 @@ import logging
 from unittest.mock import patch
 
 from .aws import get_secret, split_s3_url, load_from_s3
+from .listify import listify
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ def secrets(
     secret_region = aws_region or os.environ.get("AWS_REGION") or "us-east-1"
 
     values = {}
-    values["LOADED_SECRET_NAMES"] = os.environ.get("LOADED_SECRET_NAMES", [])
+    values["LOADED_SECRET_NAMES"] = listify(os.environ.get("LOADED_SECRET_NAMES", []))
 
     # if not secret_name and os.environ.get("SECRET_NAME"):
     #     secret_name = os.environ.get("SECRET_NAME")

--- a/src/stac_utils/secret_context.py
+++ b/src/stac_utils/secret_context.py
@@ -56,26 +56,27 @@ def secrets(
 
     for secret_key in secret_names:
         if secret_key not in values["LOADED_SECRET_NAMES"]:
-            logger.info(f'Loading secret {secret_key} from region {secret_region}')
+            key_from_environ = os.environ.get(secret_key)
+            logger.info(f'Loading secret {key_from_environ} from region {secret_region}')
 
             secret_vals = get_secret(
                 secret_region,
-                secret_key,
+                key_from_environ,
             )
 
             overlapping_keys = set(values) & set(secret_vals)
 
             if overlapping_keys: 
-                err_msg = f'Loading secret {secret_key} would overwrite the following keys: {overlapping_keys}. Execution will stop to prevent any unwanted behavior.'
+                err_msg = f'Loading secret {key_from_environ} would overwrite the following keys: {overlapping_keys}. Execution will stop to prevent any unwanted behavior.'
                 logger.error(err_msg)
                 raise ValueError(err_msg)
             
             values.update(secret_vals)
-            values["LOADED_SECRET_NAMES"].append(secret_key)
+            values["LOADED_SECRET_NAMES"].append(key_from_environ)
 
-            logger.info(f'Successfully loaded {len(secret_vals)} values from secret {secret_key}')
+            logger.info(f'Successfully loaded {len(secret_vals)} values from secret {key_from_environ}')
         else:
-            logger.info(f'Secret {secret_key} already loaded - skipping')
+            logger.info(f'Secret {key_from_environ} already loaded - skipping')
 
     if not s3_url and os.environ.get("SECRET_S3_URL"):
         s3_url = os.environ.get("SECRET_S3_URL")


### PR DESCRIPTION
### Checklist for this pull request:
- [ ] I have added docstrings to my additions if needed
- [ ] I have added the module to docs/index.rst if it is completely new

### Description:

- add logging
- add tracking of which secrets have been loaded to reduce round trips to AWS Secret Manager
- consider `SECRET_NAME_` environment variables to be AWS secrets and load them 