### PR TITLE
include ServiceUnavailable in retry exceptions for google utils

### DIFF
--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -6,7 +6,7 @@ import sys
 
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
-from google.api_core.exceptions import InternalServerError, NotFound
+from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
 from google.api_core.retry import if_exception_type, Retry
 from google.cloud import storage, bigquery
 from google.cloud.bigquery.table import Table
@@ -23,7 +23,7 @@ except ImportError:
 
 from .listify import listify
 
-RETRY_EXCEPTIONS = [InternalServerError]
+RETRY_EXCEPTIONS = [InternalServerError, ServiceUnavailable]
 
 logging.basicConfig()
 


### PR DESCRIPTION
### Checklist for this pull request:
- [x] I have added docstrings to my additions if needed
- [x] I have added the module to docs/index.rst if it is completely new

### Description:
adding ServiceUnavailable to retry exceptions to try to solve repeated 503 we see when ticker tries to write to bigquery

---

![image](https://github.com/user-attachments/assets/e0a10287-638f-4f03-870c-51e8281ec914)

[aw man](https://www.youtube.com/watch?v=cPJUBQd-PNM)

[creeper stole all his stuff again](https://youtu.be/kDqiy43LAWE)
