### PR TITLE
use actual base url for reach auth endpoint

### DIFF
--- a/src/stac_utils/reach.py
+++ b/src/stac_utils/reach.py
@@ -33,9 +33,10 @@ class ReachClient(HTTPClient):
             "username": self.api_user,
             "password": self.api_password,
         }
+        actual_base_url = "https://api.reach.vote"
         endpoint = "/oauth/token"
         session = requests.Session()
-        response = session.post(self.base_url + endpoint, data=body)
+        response = session.post(actual_base_url + endpoint, data=body)
         self.access_token = json.loads(response.text)["access_token"]
 
     def create_session(self) -> requests.Session:

--- a/src/stac_utils/reach.py
+++ b/src/stac_utils/reach.py
@@ -20,6 +20,8 @@ class ReachClient(HTTPClient):
     """
 
     base_url = "https://api.reach.vote/api/v1"
+    actual_base_url = "https://api.reach.vote"
+
 
     def __init__(self, api_user: str = None, api_password: str = None, *args, **kwargs):
         self.api_user = api_user or os.environ["REACH_API_USER"]
@@ -33,10 +35,9 @@ class ReachClient(HTTPClient):
             "username": self.api_user,
             "password": self.api_password,
         }
-        actual_base_url = "https://api.reach.vote"
         endpoint = "/oauth/token"
         session = requests.Session()
-        response = session.post(actual_base_url + endpoint, data=body)
+        response = session.post(self.actual_base_url + endpoint, data=body)
         self.access_token = json.loads(response.text)["access_token"]
 
     def create_session(self) -> requests.Session:

--- a/src/stac_utils/reach.py
+++ b/src/stac_utils/reach.py
@@ -22,7 +22,6 @@ class ReachClient(HTTPClient):
     base_url = "https://api.reach.vote/api/v1"
     actual_base_url = "https://api.reach.vote"
 
-
     def __init__(self, api_user: str = None, api_password: str = None, *args, **kwargs):
         self.api_user = api_user or os.environ["REACH_API_USER"]
         self.api_password = api_password or os.environ["REACH_API_PASSWORD"]

--- a/src/tests/test_reach.py
+++ b/src/tests/test_reach.py
@@ -39,10 +39,9 @@ class TestReachClient(unittest.TestCase):
             "username": test_client.api_user,
             "password": test_client.api_password,
         }
-        actual_base_url = "https://api.reach.vote"
         endpoint = "/oauth/token"
         mock_session.return_value.post.assert_called_once_with(
-            actual_base_url + endpoint, data=test_body
+            test_client.actual_base_url + endpoint, data=test_body
         )
 
     def test_create_session(self):

--- a/src/tests/test_reach.py
+++ b/src/tests/test_reach.py
@@ -39,9 +39,10 @@ class TestReachClient(unittest.TestCase):
             "username": test_client.api_user,
             "password": test_client.api_password,
         }
+        actual_base_url = "https://api.reach.vote"
         endpoint = "/oauth/token"
         mock_session.return_value.post.assert_called_once_with(
-            test_client.base_url + endpoint, data=test_body
+            actual_base_url + endpoint, data=test_body
         )
 
     def test_create_session(self):


### PR DESCRIPTION
### Checklist for this pull request:
- [ ] I have added docstrings to my additions if needed
- [ ] I have added the module to docs/index.rst if it is completely new

### Description:
Did nothing but update the base url for hitting the Reach endpoint for creating OAuth token