### PR TITLE
Update error logs for get_credentials

### DIFF
--- a/src/stac_utils/google.py
+++ b/src/stac_utils/google.py
@@ -50,8 +50,8 @@ def get_credentials(
         try:
             service_account_blob = json.loads(os.environ[service_account_env_name])
         except (json.JSONDecodeError, KeyError) as e:
-            print("Service account did not load correctly")
-            print(e)
+            logger.error(f"Service account did not load correctly from environment named {service_account_env_name}")
+            logger.error(e)
             return None
 
     if isinstance(scopes, str):

--- a/src/tests/test_google.py
+++ b/src/tests/test_google.py
@@ -63,7 +63,10 @@ class TestGoogle(unittest.TestCase):
     def test_get_credentials_missing(self):
         """Test credentials returns None because no credentials were provided"""
 
-        self.assertIsNone(get_credentials(scopes="foo"))
+        with self.assertLogs(None, level="INFO") as cm:
+            self.assertIsNone(get_credentials(scopes="foo"))
+
+        self.assertIn('ERROR:src.stac_utils.google:Service account did not load correctly from environment named SERVICE_ACCOUNT', cm.output[0])
 
     @patch("src.stac_utils.google.get_credentials")
     def test_get_client(self, mock_get_credentials: MagicMock):


### PR DESCRIPTION
### Checklist for this pull request:
- [x] I have added docstrings to my additions if needed
- [x] I have added the module to docs/index.rst if it is completely new

### Description:

Update to the `get_credentials` method in `google.py` to log service account failures to load as errors rather than print statements. Should work when using either default credentials or a named key if neither would load as a valid JSON.

Note this method still **does** **not** validate the credentials will do the task you need, just that valid credentials could be created from the JSON provided. 